### PR TITLE
Add a menu scenario to unplug the vehicle

### DIFF
--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -19,12 +19,14 @@
     <string id="menu_label_trunk">Coffre</string>
     <string id="menu_label_open_charge_port">Ouvrir trappe</string>
     <string id="menu_label_close_charge_port">Fermer trappe</string>
+    <string id="menu_label_unplug">*Débrancher*</string>
 
 	<!--  Second view -->
     <string id="label_cabin">Temp: </string>
     <string id="label_charge">Charge: </string>
     <string id="label_charge_port_closed">Trappe fermée</string>
     <string id="label_charge_port_opened">Trappe ouverte</string>
+    <string id="label_charge_stopped">Charge arrêtée</string>
     <string id="label_climate">Clim: </string>
     <string id="label_error">Erreur: </string>
     <string id="label_frunk">Coffre av.</string>
@@ -40,7 +42,6 @@
     <string id="label_off">Off</string>
     <string id="label_on">On</string>
     <string id="label_open_frunk">Ouvrir coffre av. ?</string>
-    <string id="label_open_trunk">Ouvrir coffre ?</string>
     <string id="label_requesting_data">Récup. données...</string>
     <string id="label_unlock_doors">Déverouillée</string>
     <string id="label_unlocked">Ouverte</string>

--- a/resources/layouts/menu.xml
+++ b/resources/layouts/menu.xml
@@ -1,4 +1,5 @@
 <menu id="OptionMenu">
+    <menu-item id="unplug" label="@Strings.menu_label_unplug" />
     <menu-item id="trunk" label="@Strings.menu_label_trunk" />
     <menu-item id="frunk" label="@Strings.menu_label_frunk" />
     <menu-item id="open_charge_port" label="@Strings.menu_label_open_charge_port" />

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -19,6 +19,7 @@
     <string id="menu_label_trunk">Trunk</string>
     <string id="menu_label_open_charge_port">Open Charge Port</string>
     <string id="menu_label_close_charge_port">Close Charge Port</string>
+    <string id="menu_label_unplug">*Unplug*</string>
 
 	<!--  Second view -->
     <string id="label_cabin">Cabin: </string>
@@ -26,6 +27,7 @@
     <string id="label_climate">Climate: </string>
     <string id="label_charge_port_closed">Charge port closed</string>
     <string id="label_charge_port_opened">Charge port opened</string>
+    <string id="label_charge_stopped">Charge stopped</string>
     <string id="label_error">Error: </string>
     <string id="label_frunk">Frunk</string>
     <string id="label_trunk">Trunk</string>
@@ -40,7 +42,6 @@
     <string id="label_off">Off</string>
     <string id="label_on">On</string>
     <string id="label_open_frunk">Open Frunk?</string>
-    <string id="label_open_trunk">Open Trunk?</string>
     <string id="label_requesting_data">Requesting data...</string>
     <string id="label_unlock_doors">Unlock Doors</string>
     <string id="label_unlocked">Unlocked</string>

--- a/source/OptionMenu.mc
+++ b/source/OptionMenu.mc
@@ -28,6 +28,8 @@ class OptionMenuDelegate extends Ui.MenuInputDelegate {
         } else if (item == :close_charge_port) {
             _controller._close_charge_port = true;
             _controller.stateMachine();
+        } else if (item == :unplug) {
+            _controller.unplugVehicle();
         } else if (item == :toggle_units) {
             var units = Application.getApp().getProperty("imperial");
             if (units) {

--- a/source/Tesla.mc
+++ b/source/Tesla.mc
@@ -88,6 +88,12 @@ class Tesla {
         _genericPost(url, null, notify);
     }
 
+    //! If the car is currently charging, this will stop it.
+    function stopCharge(vehicle, notify) {
+        var url = TESLA_API + vehicle.toString() + "/command/charge_stop";
+        _genericPost(url, null, notify);
+    }
+
     hidden function _genericGet(url, notify) {
         System.println("GET: " + url);
         Communications.makeWebRequest(


### PR DESCRIPTION
When selecting "Unplug" from the context menu, unlock the doors, open the trunk to store the cable, stop the charge. No confirmation is needed.