### PR TITLE
New layout for touch devices (vivoactive 3)

### DIFF
--- a/resources-vivoactive3/layouts/main.xml
+++ b/resources-vivoactive3/layouts/main.xml
@@ -1,6 +1,5 @@
 <layout id="TeslaLayout">
     <!-- button labels -->
-    <label x="15" y="center" font="Graphics.FONT_XTINY" text="@Strings.button_frunk" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT" />
-    <label x="20" y="160" font="Graphics.FONT_XTINY" text="@Strings.button_door" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_LEFT" />
-    <label x="210" y="60" font="Graphics.FONT_XTINY" text="@Strings.button_climate_on" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_RIGHT" />
+    <label x="center" y="7" font="Graphics.FONT_XTINY" text="@Strings.button_frunk" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+    <label x="center" y="210" font="Graphics.FONT_XTINY" text="@Strings.button_door" color="Gfx.COLOR_BLUE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
 </layout>

--- a/source/SecondDelegate.mc
+++ b/source/SecondDelegate.mc
@@ -191,6 +191,7 @@ class SecondDelegate extends Ui.BehaviorDelegate {
         stateMachine();
     }
 
+    //! When select button is pressed or screen is touched
     function onSelect() {
         if (_data._climate != null && _data._climate.hasKey("is_climate_on") && !_data._climate.get("is_climate_on")) {
             _set_climate_on = true;
@@ -201,6 +202,7 @@ class SecondDelegate extends Ui.BehaviorDelegate {
         return true;
     }
 
+    //! When down button is pressed or screen is swipped up
     function onNextPage() {
         if (_data._vehicle != null && !_data._vehicle.get("locked")) {
             _lock = true;
@@ -211,17 +213,20 @@ class SecondDelegate extends Ui.BehaviorDelegate {
         return true;
     }
 
+    //! When up button is pressed or screen is swipped down
     function onPreviousPage() {
         _open_frunk = true;
         stateMachine();
         return true;
     }
 
+    //! When back button is pressed or screen is swipped right
     function onBack() {
         Ui.popView(Ui.SLIDE_DOWN);
         return true;
     }
 
+    //! When back button is held down or screen is long-touched
     function onMenu() {
         Ui.pushView(new Rez.Menus.OptionMenu(), new OptionMenuDelegate(self), Ui.SLIDE_UP);
         return true;


### PR DESCRIPTION
The idea is to provide a layout specifically for touch devices, where the buttons correpond to swipe gestures.

* Select button is pressed corresponds to screen is touched
* Down button is pressed corresponds to screen is swipped up
* Up button is pressed corresponds to screen is swipped down
* Up button is held down (menu button) corresponds to screen is long-touched
* Back button is pressed corresponds to screen is swipped right
