### PR TITLE
Use Tesla authentication method from settings

### DIFF
--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -48,8 +48,7 @@
     <string id="label_hvac_off">Clim éteinte</string>
     <string id="label_lock_doors">Vérouillée</string>
     <string id="label_locked">Fermée</string>
-    <string id="label_login_on_phone">Connexion sur tél.</string>
-    <string id="label_oauth_error">Erreur OAuth</string>
+    <string id="label_oauth_error">Erreur d'auth.</string>
     <string id="label_off">Off</string>
     <string id="label_on">On</string>
     <string id="label_open_frunk">Ouvrir coffre av. ?</string>
@@ -61,4 +60,8 @@
 	<!--  Settings -->
     <string id="setting_token_label">Clé d'API</string>
     <string id="setting_token_prompt">Entrer la clé d'API Tesla (Token)</string>
+    <string id="setting_email_label">Email</string>
+    <string id="setting_email_prompt">Entrer votre identifiant Tesla (Email)</string>
+    <string id="setting_password_label">Password</string>
+    <string id="setting_password_prompt">Enter votre mot de passe Tesla</string>
 </strings>

--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -48,6 +48,7 @@
     <string id="label_hvac_off">Clim éteinte</string>
     <string id="label_lock_doors">Vérouillée</string>
     <string id="label_locked">Fermée</string>
+    <string id="label_login_on_phone">Connexion sur tél.</string>
     <string id="label_oauth_error">Erreur d'auth.</string>
     <string id="label_off">Off</string>
     <string id="label_on">On</string>

--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -6,4 +6,6 @@
 
 	<!--  Settings -->
 	<property id="token" type="string"></property>
+	<property id="email" type="string"></property>
+	<property id="password" type="string"></property>
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -2,4 +2,10 @@
 	<setting propertyKey="@Properties.token" title="@Strings.setting_token_label" prompt="@Strings.setting_token_prompt">
 		<settingConfig type="alphaNumeric" />
 	</setting>
+	<setting propertyKey="@Properties.email" title="@Strings.setting_email_label" prompt="@Strings.setting_email_prompt">
+		<settingConfig type="alphaNumeric" />
+	</setting>
+	<setting propertyKey="@Properties.password" title="@Strings.setting_password_label" prompt="@Strings.setting_password_prompt">
+		<settingConfig type="alphaNumeric" />
+	</setting>
 </settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -48,6 +48,7 @@
     <string id="label_hvac_off">HVAC Off</string>
     <string id="label_lock_doors">Lock Doors</string>
     <string id="label_locked">Locked</string>
+    <string id="label_login_on_phone">Login on Phone!</string>
     <string id="label_oauth_error">Auth. error</string>
     <string id="label_off">Off</string>
     <string id="label_on">On</string>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -48,8 +48,7 @@
     <string id="label_hvac_off">HVAC Off</string>
     <string id="label_lock_doors">Lock Doors</string>
     <string id="label_locked">Locked</string>
-    <string id="label_login_on_phone">Login on Phone!</string>
-    <string id="label_oauth_error">OAuth error</string>
+    <string id="label_oauth_error">Auth. error</string>
     <string id="label_off">Off</string>
     <string id="label_on">On</string>
     <string id="label_open_frunk">Open Frunk?</string>
@@ -60,5 +59,9 @@
 
 	<!--  Settings -->
     <string id="setting_token_label">API Token</string>
-    <string id="setting_token_prompt">Enter your Tesla Account token</string>
+    <string id="setting_token_prompt">Enter your Tesla account token</string>
+    <string id="setting_email_label">Email</string>
+    <string id="setting_email_prompt">Enter your Tesla account user ID (Email)</string>
+    <string id="setting_password_label">Password</string>
+    <string id="setting_password_prompt">Enter your Tesla account password</string>
 </strings>

--- a/source/SecondDelegate.mc
+++ b/source/SecondDelegate.mc
@@ -9,8 +9,6 @@ class SecondDelegate extends Ui.BehaviorDelegate {
     hidden var _tesla;
     hidden var _sleep_timer;
     hidden var _vehicle_id;
-    hidden var _need_auth;
-    hidden var _auth_done;
     hidden var _need_wake;
     hidden var _wake_done;
 
@@ -41,13 +39,6 @@ class SecondDelegate extends Ui.BehaviorDelegate {
         _handler = handler;
         _tesla = null;
 
-        if (_token != null) {
-            _need_auth = false;
-            _auth_done = true;
-        } else {
-            _need_auth = true;
-            _auth_done = false;
-        }
         _need_wake = false;
         _wake_done = true;
 
@@ -173,24 +164,9 @@ class SecondDelegate extends Ui.BehaviorDelegate {
             return;
         }
 
-        if (_need_auth) {
-            _need_auth = false;
-            _handler.invoke(Ui.loadResource(Rez.Strings.label_login_on_phone));
-            Communications.registerForOAuthMessages(method(:onOAuthMessage));
-            Communications.makeOAuthRequest(
-                "https://dasbrennen.org/tesla/tesla.html",
-                {},
-                "https://dasbrennen.org/tesla/tesla-done.html",
-                Communications.OAUTH_RESULT_TYPE_URL,
-                {
-                    "responseCode" => "OAUTH_CODE",
-                    "responseError" => "OAUTH_ERROR"
-                }
-            );
-            return;
-        }
-
-        if (!_auth_done) {
+        if (_token == null) {
+            _tesla = new Tesla(null);
+            _tesla.authenticate(Settings.getEmail(), Settings.getPassword(), method(:onAuthentication));
             return;
         }
 
@@ -436,9 +412,9 @@ class SecondDelegate extends Ui.BehaviorDelegate {
         }
     }
 
-    function onOAuthMessage(message) {
-        if (message.data != null) {
-            _saveToken(message.data["OAUTH_CODE"]);
+    function onAuthentication(token) {
+        if (token != null) {
+            _saveToken(token);
             _stateMachine();
         } else {
             _resetToken();
@@ -489,13 +465,11 @@ class SecondDelegate extends Ui.BehaviorDelegate {
 
     hidden function _saveToken(token) {
         _token = token;
-        _auth_done = true;
         Settings.setToken(token);
     }
 
     hidden function _resetToken() {
         _token = null;
-        _auth_done = false;
         Settings.setToken(null);
     }
 

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -13,11 +13,30 @@ module Settings {
     //! Get auth token
     function getToken() {
         var value = Application.getApp().getProperty(TOKEN);
+        if (value == "") {
+            value = null;
+        }
         System.println("Settings: token value is " + value);
+        return value;
+    }
+
+    //! Get Tesla account email
+    function getEmail() {
+        var value = Application.getApp().getProperty(EMAIL);
+        System.println("Settings: account email is " + value);
+        return value;
+    }
+
+    //! Get Tesla account password
+    function getPassword() {
+        var value = Application.getApp().getProperty(PASSWORD);
+        System.println("Settings: account password is *****");
         return value;
     }
 
 
     // Settings name, see resources/settings/settings.xml
     const TOKEN = "token";
+    const EMAIL = "email";
+    const PASSWORD = "password";
 }

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -12,28 +12,34 @@ module Settings {
 
     //! Get auth token
     function getToken() {
-        var value = Application.getApp().getProperty(TOKEN);
-        if (value == "") {
-            value = null;
-        }
+        var value = _getStringProperty(TOKEN);
         System.println("Settings: token value is " + value);
         return value;
     }
 
     //! Get Tesla account email
     function getEmail() {
-        var value = Application.getApp().getProperty(EMAIL);
+        var value = _getStringProperty(EMAIL);
         System.println("Settings: account email is " + value);
         return value;
     }
 
     //! Get Tesla account password
     function getPassword() {
-        var value = Application.getApp().getProperty(PASSWORD);
+        var value = _getStringProperty(PASSWORD);
         System.println("Settings: account password is *****");
         return value;
     }
 
+    hidden function _getStringProperty(propertyName) {
+        var value = Application.getApp().getProperty(propertyName);
+        if (value == null || !(value instanceof Toybox.Lang.String) || "".equals(value)) {
+            value = null;
+        } else {
+            value = value.toString();
+        }
+        return value;
+    }
 
     // Settings name, see resources/settings/settings.xml
     const TOKEN = "token";

--- a/source/Tesla.mc
+++ b/source/Tesla.mc
@@ -1,7 +1,8 @@
 class Tesla {
     hidden var _token;
-    hidden var _notify;
+    hidden var _callback;
     hidden const TESLA_API = "https://owner-api.teslamotors.com/api/1/vehicles/";
+
 
     function initialize(token) {
         if (token != null) {
@@ -99,6 +100,44 @@ class Tesla {
         _genericPost(url, null, notify);
     }
 
+    //! Authenticate against the Tesla servers, request for a token which is
+    //! returned as argument of the callback: notify(token)
+    function authenticate(email, password, notify) {
+        _callback = notify;
+        var url = "https://owner-api.teslamotors.com/oauth/token/";
+        var params = {
+            "grant_type" => "password",
+            "client_id" => "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384",
+            "client_secret" => "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3",
+            "email" => email,
+            "password" => password
+        };
+
+        Communications.makeWebRequest(
+            url,
+            params,
+            {
+                :method => Communications.HTTP_REQUEST_METHOD_POST,
+                :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
+            },
+            method(:_onAuthenticateResult)
+        );
+    }
+
+    function _onAuthenticateResult(responseCode, data) {
+        var token = null;
+        if (responseCode == 200) {
+            token = data.get("access_token");
+            System.println("Authentication token: " + token);
+            _token = "Bearer " + data.get("access_token");
+        } else {
+            System.println("Authentication error: " + responseCode.toString());
+        }
+        if (_callback != null) {
+            _callback.invoke(token);
+        }
+    }
+
     hidden function _genericGet(url, notify) {
         System.println("GET: " + url);
         Communications.makeWebRequest(
@@ -131,12 +170,4 @@ class Tesla {
         );
     }
 
-
-    //function authCallback(responseCode, data) {
-    //    if (responseCode == 200) {
-    //        Application.getApp().setProperty("token", data.get("access_token"));
-    //        _token = "Bearer " + data.get("access_token");
-    //    }
-    //    _notify.invoke(responseCode, data);
-    //}
 }

--- a/source/Tesla.mc
+++ b/source/Tesla.mc
@@ -104,7 +104,9 @@ class Tesla {
     //! returned as argument of the callback: notify(token)
     function authenticate(email, password, notify) {
         _callback = notify;
+
         var url = "https://owner-api.teslamotors.com/oauth/token/";
+
         var params = {
             "grant_type" => "password",
             "client_id" => "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384",
@@ -113,15 +115,12 @@ class Tesla {
             "password" => password
         };
 
-        Communications.makeWebRequest(
-            url,
-            params,
-            {
-                :method => Communications.HTTP_REQUEST_METHOD_POST,
-                :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
-            },
-            method(:_onAuthenticateResult)
-        );
+        var options = {
+            :method => Communications.HTTP_REQUEST_METHOD_POST,
+            :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
+        };
+
+        Communications.makeWebRequest(url, params, options, method(:_onAuthenticateResult));
     }
 
     function _onAuthenticateResult(responseCode, data) {


### PR DESCRIPTION
Add email and password as app settings.
Use email/password to get a token, store the token as app setting.

If existing token is null or rejected, create a new token.

To create a token, use Tesla's email/password authentication with email/password from app settings.
But if email or password is not set in app settings, use website authentication on phone.
In any case, the token created is saved as an app setting for the next sessions.

![image](https://user-images.githubusercontent.com/312886/71323438-6d611600-24d3-11ea-9257-4bcf21f7421b.png)
